### PR TITLE
build hotfix: gcc does not have __fs

### DIFF
--- a/src/pipelines/TexturedTrianglePipeline.hpp
+++ b/src/pipelines/TexturedTrianglePipeline.hpp
@@ -70,7 +70,12 @@ public:
     void onFrame(wgpu::TextureView &textureView, wgpu::CommandEncoder &commandEncoder) override;
 };
 
+#ifdef __APPLE__
 namespace fs = std::__fs::filesystem;
+#else
+namespace fs = std::filesystem;
+#endif
+
 bool loadTexturedObjIntoTriangleData(const fs::path& path, std::vector<UVTriangleVertexAttributes> &vertexData);
 
 

--- a/src/pipelines/TrianglePipeline.hpp
+++ b/src/pipelines/TrianglePipeline.hpp
@@ -67,5 +67,10 @@ public:
     void onFrame(wgpu::TextureView &textureView, wgpu::CommandEncoder &commandEncoder) override;
 };
 
+#ifdef __APPLE__
 namespace fs = std::__fs::filesystem;
+#else
+namespace fs = std::filesystem;
+#endif;
+
 bool loadObjIntoTriangleData(const fs::path& path, std::vector<TriangleVertexAttributes> &vertexData);


### PR DESCRIPTION
Please test this on Apple Silicon but this fixes the build issues seen on Ubuntu 22.04.3 LTS (Jammy Jellyfish)